### PR TITLE
feat: add new 'published' output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A semantic-release plugin to output values from a GitHub Action.
 
 | Step               | Description                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------- |
-| `verifyConditions` | Sets GitHub Action output variables `published` to false                                     |
+| `verifyConditions` | Sets GitHub Action output variable `published` to false                                     |
 | `verifyRelease`    | Sets GitHub Action output variables `tag` & `version`                                        |
-| `success`          | Sets GitHub Action output variables `published` to true                                      |
+| `success`          | Sets GitHub Action output variable `published` to true                                      |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install semantic-release-gha-output
 | ------------------ | -------------------------------------------------------------------------------------------- |
 | `tag`              | Next release git tag.                                                                        |
 | `version`          | Next release version.                                                                        |
-| `published`        | Boolean to indicate whether a new release was published.                                     |
+| `published`        | Boolean string to indicate whether a new release was published.                              |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A semantic-release plugin to output values from a GitHub Action.
 
 | Step               | Description                                                                                  |
 | ------------------ | -------------------------------------------------------------------------------------------- |
-| `verifyRelease`    | Sets GitHub Action output variables.                                                         |
+| `verifyConditions` | Sets GitHub Action output variables `published` to false                                     |
+| `verifyRelease`    | Sets GitHub Action output variables `tag` & `version`                                        |
+| `success`          | Sets GitHub Action output variables `published` to true                                      |
 
 ## Install
 
@@ -20,6 +22,7 @@ $ npm install semantic-release-gha-output
 | ------------------ | -------------------------------------------------------------------------------------------- |
 | `tag`              | Next release git tag.                                                                        |
 | `version`          | Next release version.                                                                        |
+| `published`        | Boolean to indicate whether a new release was published.                                     |
 
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -1,10 +1,20 @@
 import { setOutput } from '@actions/core';
 
+function verifyConditions() {
+  setOutput("published", "false");
+}
+
 function verifyRelease(_pluginConfig, { nextRelease }) {
   setOutput("tag", nextRelease.gitTag);
   setOutput("version", nextRelease.version);
 }
 
+function success() {
+  setOutput("published", "true");
+}
+
 export default {
+  verifyConditions,
   verifyRelease,
+  success,
 };


### PR DESCRIPTION
Create new GHA output variable called `published`. Boolean string to indicate whether a new release has been published.