### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.0-development",
   "type": "module",
   "homepage": "https://github.com/zachspar/semantic-release-gha-output",
-  "repository": "git@github.com:zachspar/semantic-release-gha-output.git",
+  "repository": "git+https://github.com/zachspar/semantic-release-gha-output.git",
   "bugs": "https://github.com/zachspar/semantic-release-gha-output/issues",
   "readme": "README.md",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Update the package `repository` metadata from the SSH GitHub form to a public HTTPS URL.
- Leave runtime code, dependencies, package version, homepage, bugs metadata, release config, and package-lock unchanged.

## Why

This repository is public, so npm consumers should be able to follow the source repository link without SSH or GitHub key setup.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository !== 'git+https://github.com/zachspar/semantic-release-gha-output.git') throw new Error(p.repository)"`
- `git diff --check`
- `pnpm pack --dry-run`

I could not run the repository's `npm ci` workflow locally because the local Codex runtime does not include an `npm` binary. I also tried pnpm as a substitute, but the existing `devDependencies` entry `"semantic-release-gha-output": "."` is not resolvable by pnpm as a registry version. This PR only changes package metadata.
